### PR TITLE
Add GT2021 secondaries

### DIFF
--- a/9e/gt2021.json
+++ b/9e/gt2021.json
@@ -1,0 +1,404 @@
+{
+	"ver": "GT_2021_01",
+	"name": "Grand Tournament 2021",
+	"factions": [
+		{
+			"name": "Generic",
+			"categories": [
+				{
+					"name": "Battlefield Supremacy",
+					"objectives": [
+						{
+							"id": "GT21.01.01.01",
+							"name": "Engage on All Fronts",
+							"description": "[i]Progressive Objective[/i]\nScore 2 victory points at the end of your turn if you have one or more units from your army wholly within three different table quarters, and those units are all more than 6” from the centre of the battlefield. Score 3 victory points instead if you have one or more units from your army wholly within each table quarter, and those units are all more than 6” from the centre of the battlefield."
+						},
+						{
+							"id": "GT21.01.01.02",
+							"name": "Behind Enemy Lines",
+							"description": "[i]Progressive Objective[/i]\nScore 2 victory points at the end of your turn if one unit from your army (excluding [b]AIRCRAFT[/b] units) is wholly within your opponent’s deployment zone. Score 4 victory points at the end of your turn instead if two or more units from your army (excluding [b]AIRCRAFT[/b] units) are wholly within your opponent’s deployment zone."
+						},
+						{
+							"id": "GT21.01.01.03",
+							"name": "Stranglehold",
+							"description": "[i]Progressive Objective[/i]\nScore 3 victory points at the end of your turn if you control 3 or more objective markers and you also control more objective markers than your opponent controls."
+						}
+					]
+				},
+				{
+					"name": "No Mercy, No Respite",
+					"objectives": [
+						{
+							"id": "GT21.01.02.01",
+							"name": "No Prisoners",
+							"description": "[i]End Game Objective[/i]\nIf you select this objective, keep a tally of kill points. Each time an enemy model is destroyed, unless that model is a [b]VEHICLE[/b], [b]MONSTER[/b] or [b]CHARACTER[/b], add a number of marks to this tally equal to the Wounds characteristic of the destroyed model. A model can, if it is resurrected for any reason (i.e. it was destroyed and subsequently returned to the battlefield), potentially have marks added to this tally several times (assuming it is resurrected and subsequently destroyed several times over). At the end of the battle, divide your kill points tally by 10 and round down - the result is the number of victory points you score."
+						},
+						{
+							"id": "GT21.01.02.02",
+							"name": "Grind Them Down",
+							"description": "[i]Progressive Objective[/i]\nScore 3 victory points at the end of the battle round if more enemy units than friendly units were destroyed this battle round."
+						},
+						{
+							"id": "GT21.01.02.03",
+							"name": "To The Last",
+							"description": "[i]End Game Objective[/i]\nIf you select this objective, then before the battle, after you have selected deployment zones, identify which three units from your army (excluding those with the Fortifications Battlefield Role) have the highest points value, and make a note of them on your army roster (if two or more are tied, you choose between them). If your army has three or fewer units, you instead identify all the units in your army. A unit’s points value includes the points of all weapons, other wargear and upgrades it has. You score 5 victory points for each of these units that are on the battlefield at the end of the battle. If a unit splits into several smaller units during the battle, all of those separate units (excluding [b]DRONE[/b] units) must be on the battlefield at the end of the battle to score 5 victory points; if some of those separate units (excluding [b]DRONE[/b] units) are on the battlefield at the end of the battle, but not all of them are, you score 3 victory points instead of 5."
+						}
+					]
+				},
+				{
+					"name": "Shadow Operations",
+					"objectives": [
+						{
+							"id": "GT21.01.03.01",
+							"name": "Raise the Banners High",
+							"description": "[i]Progressive and End Game Objective[/i]\nIf you select this objective, then units in your army can perform the following action. You score 1 victory point at the end of each of your Command phases, and 1 victory point at the end of the battle, for each objective marker on the battlefield that has one of your banners raised upon it.",
+							"actions": [
+								{
+									"id": "GT21.01.03.01a",
+									"name": "Raise Banners (Action)",
+									"description": "[i]Action[/i]\nOne or more [b]INFANTRY[/b] units from your army can start to perform this action at the end of your Movement phase. Each unit from your army that starts to perform this action must be in range of a different objective marker that does not have one of your banners raised upon it (see below). A unit cannot start this action while there are any enemy units (excluding [b]AIRCRAFT[/b]) in range of the same objective marker. The action is completed at the end of your turn. If this action is successfully completed, that objective marker is said to have one of your army’s banners raised on it (the banner is ‘removed’ if your opponent controls the objective marker at the start of any phase)."
+								}
+							]
+						},
+						{
+							"id": "GT21.01.03.02",
+							"name": "Investigate Signal",
+							"description": "[i]Progressive Objective[/i]\nScore 3 victory points each time a unit from your army successfully completes the following action.",
+							"actions": [
+								{
+									"id": "GT21.01.03.02a",
+									"name": "Investigate Signal (Action)",
+									"description": "[i]Action[/i]\nOne [b]INFANTRY[/b] unit (excluding [b]CHARACTER[/b] units) from your army can start to perform this action at the end of your Movement phase if it is wholly within 6” of the centre of the battlefield and no enemy units (excluding [b]AIRCRAFT[/b] units) are wholly within 6” of the centre of the battlefield. The action is completed at the end of your turn provided the unit attempting it is still wholly within 6” of the centre of the battlefield and no enemy units (excluding [b]AIRCRAFT[/b] units) are wholly within 6” of the centre of the battlefield."
+								}
+							]
+						},
+						{
+							"id": "GT21.01.03.03",
+							"name": "Retrieve Octarius Data",
+							"description": "[i]End Game Objective[/i]\nIf you select this objective, keep a tally of Retrieved Data points; add 1 to that tally each time a unit from your army successfully completes the following action during the battle. At the end of the battle, score 4 victory points if your Retrieved Data tally is 2, score 8 victory points if your tally is 3, or score 12 victory points if your tally is 4.",
+							"actions": [
+								{
+									"id": "GT21.01.03.03a",
+									"name": "Retrieve Data (Action)",
+									"description": "[i]Action[/i]\nOne [b]INFANTRY[/b] unit (excluding [b]CHARACTER[/b] units) from your army can start to perform this action at the end of your Movement phase if it is wholly within a table quarter that has not had a servo-skull retrieved by your army (see below) and it is more than 6” away from any other table quarter. This action is completed at the end of your turn provided the unit attempting it is still within the same table quarter. If this action is successfully completed, the table quarter is said to have had a servo-skull retrieved by your army."
+								}
+							]
+						},
+						{
+							"id": "GT21.01.03.04",
+							"name": "Deploy Teleport Homers",
+							"description": "[i]Progressive Objective[/i]\nIf you select this objective, then units from your army can perform the following action. Each time a unit from your army successfully completes this action, you score 2 victory points (you score 4 victory points instead if the unit completed the action while wholly within your opponent's deployment zone).",
+							"actions": [
+								{
+									"id": "GT21.01.03.04a",
+									"name": "Deploy Teleport Homer (Action)",
+									"description": "[i]Action[/i]\nOne [b]INFANTRY[/b] or [b]BIKER[/b] unit from your army can start to perform this action at the end of your Movement phase if it is wholly within 12” of your opponent's deployment zone. The action is completed at the end of your next Command phase provided the unit attempting it is still wholly within 12” of your opponent's deployment zone."
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Purge the Enemy",
+					"objectives": [
+						{
+							"id": "GT21.01.04.01",
+							"name": "Assassination",
+							"description": "[i]End Game Objective[/i]\nScore 3 victory points at the end of the battle for each enemy [b]CHARACTER[/b] model that is destroyed. If the enemy [b]WARLORD[/b] was destroyed during the battle, gain 1 additional victory point."
+						},
+						{
+							"id": "GT21.01.04.02",
+							"name": "Titan Hunter",
+							"description": "[i]End Game Objective[/i]\nScore 4 victory points at the end of the battle if one enemy [b]TITANIC[/b] model is destroyed, 9 victory points if two enemy [b]TITANIC[/b] models are destroyed, or 15 victory points if three or more enemy [b]TITANIC[/b] models are destroyed."
+						},
+						{
+							"id": "GT21.01.04.03",
+							"name": "Bring it Down",
+							"description": "[i]End Game Objective[/i]\nScore 1 victory point at the end of the battle for each enemy [b]MONSTER[/b] or [b]VEHICLE[/b] model with a Wounds characteristic of 10 or less that is destroyed, 2 victory points for each enemy [b]MONSTER[/b] or [b]VEHICLE[/b] model with a Wounds characteristic of between 11-19 that is destroyed, and 3 victory points for each enemy [b]MONSTER[/b] or [b]VEHICLE[/b] model with a Wounds characteristic of 20 or more that is destroyed."
+						}
+					]
+				},
+				{
+					"name": "Warpcraft",
+					"objectives": [
+						{
+							"id": "GT21.01.05.01",
+							"name": "Abhor the Witch",
+							"description": "[i]End Game Objective[/i]\nYou cannot select this secondary objective if your army includes any [b]PSYKER[/b] units. Score 3 victory points at the end of the battle for each enemy [b]PSYKER CHARACTER[/b] unit that is destroyed, and 2 victory points for every other enemy [b]PSYKER[/b] unit that is destroyed."
+						},
+						{
+							"id": "GT21.01.05.02",
+							"name": "Warp Ritual",
+							"description": "[i]End Game Objective[/i]\nIf you select this objective, keep a tally of Ritual points; add 1 to that tally each time a unit from your army successfully completes the following psychic action during the battle. At the end of the battle, score 3 victory points if your Ritual tally is 1, score 7 victory points if your tally is 2, or score 12 victory points if your tally is 3 or more.",
+							"actions": [
+								{
+									"id": "GT21.01.05.02a",
+									"name": "Warp Ritual (Psychic Action)",
+									"description": "[i]Psychic Action - Warp Charge 3[/i]\nOne [b]PSYKER CHARACTER[/b] unit from your army can attempt to perform this psychic action in your Psychic phase if it is within 6” of the centre of the battlefield."
+								}
+							]
+						},
+						{
+							"id": "GT21.01.05.03",
+							"name": "Pierce the Veil",
+							"description": "[i]End Game Objective[/i]\nScore 8 victory points at the end of the battle if one or more units from your army successfully completed the following psychic action 2 or more times times during the battle, or 15 victory points at the end of the battle if one or more units from your army successfully completed the following action 4 times during the battle (note that you can only score this objective once).",
+							"actions": [
+								{
+									"id": "GT21.01.05.03a",
+									"name": "Pierce the Veil (Psychic Action)",
+									"description": "[i]Psychic Action - Warp Charge 4[/i]\nOne [b]PSYKER CHARACTER[/b] unit from your army can attempt to perform this psychic action in your Psychic phase if it is within 6” of your opponent's battlefield edge and more than 6” from any enemy models."
+								}
+							]
+						},
+						{
+							"id": "GT21.01.05.04",
+							"name": "Psychic Interrogation",
+							"description": "[i]Progressive Objective[/i]\nScore 3 victory points each time you successfully complete the following psychic action.",
+							"actions": [
+								{
+									"id": "GT21.01.05.04a",
+									"name": "Psychic Interrogation (Psychic Action)",
+									"description": "[i]Psychic Action - Warp Charge 4[/i]\nOne [b]PSYKER CHARACTER[/b] unit from your army can attempt to perform this psychic action in your Psychic phase if it is within 24” of any visible enemy [b]CHARACTER[/b] models."
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Mission Specific",
+			"categories": [
+				{
+					"name": "Crossfire",
+					"objectives": [
+						{
+							"id": "GT21.00.01.01",
+							"name": "Outflank",
+							"description": "[i]Progressive Objective[/i]\nAt the end of your Command phase, you score 3 victory points if you control both of the objective markers labelled A. Score 5 victory points instead if, at the end of your Command phase, you control both of the objective markers labelled A and there is at least one enemy unit within 9\" of the centre of the battlefield. This secondary objective cannot be scored in the first battle round."
+						}
+					]
+				},
+				{
+					"name": "Resupply",
+					"objectives": [
+						{
+							"id": "GT21.00.02.01",
+							"name": "Secure Landing Sites",
+							"description": "[i]Progressive Objective[/i]\nScore a number of victory points at the end of your Command phase for each objective marker labelled A that you control, as shown in the table below (note that the victory points scored changes depending upon the battle round number): 2 gives 2pts, 3 gives 2pts, 4 gives 3pts, 5 gives 6pts. This secondary objective cannot be scored in the first battle round."
+						}
+					]
+				},
+				{
+					"name": "Raid",
+					"objectives": [
+						{
+							"id": "GT21.00.03.01",
+							"name": "Minimize",
+							"description": "[i]Progressive Objective[/i]\nAt the end of each of your Command phases, you score 3 victory points if you control one of the objective markers that is in your opponent's deployment zone, or 5 victory points if you control both of the objective markers that are in your opponent's deployment zone. This secondary objective cannot be scored in the first battle round."
+						}
+					]
+				},
+				{
+					"name": "Centre Ground",
+					"objectives": [
+						{
+							"id": "GT21.00.04.01",
+							"name": "Centre Ground",
+							"description": "[i]Progressive Objective[/i]\nEach time a unit from your army successfully completes the following action, you score 3 victory points if you currently control one of the objective markers labelled A, or 5 victory points if you currently control both objective markers labelled A.",
+							"actions": [
+								{
+									"id": "GT21.00.04.01a",
+									"name": "Centre Ground (Action)",
+									"description": "[i]Action[/i]\nOne unit from your army can start to perform this action at the end of your Movement phase if it is within range of an objective marker labelled A and no enemy units (excluding [b]AIRCRAFT[/b]) are within range of that objective marker. The action is completed at the end of your next Command phase, so long as the unit performing it is still within range of the same objective marker."
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Ascension",
+					"objectives": [
+						{
+							"id": "GT21.00.05.01",
+							"name": "Ascend",
+							"description": "[i]Progressive Objective[/i]\nAt the end of each of your turns, if you control the central objective marker you score a number of victory points equal to the current battle round number (so 1 victory point in the first battle round, 2 victory points in the second battle round, etc.). In addition, at the end of each of your turns you score 1 victory point if your [b]WARLORD[/b] is within range of the central objective marker."
+						}
+					]
+				},
+				{
+					"name": "Forward Push",
+					"objectives": [
+						{
+							"id": "GT21.00.06.01",
+							"name": "Forward Push",
+							"description": "[i]Progressive Objective[/i]\nIf you select this objective, then units in your army can perform the following action.",
+							"actions": [
+								{
+									"id": "EW.00.06.01a",
+									"name": "Forward Push (Action)",
+									"description": "[i]Action[/i]\nOne unit from your army can start to perform this action at the start of your Movement phase if it is within range of an objective marker that you control. The action is completed at the end of your turn and you score a number of victory points depending on which objective marker this action was performed on: A 1/8 , B 2/4, C 4/2, D 8/1"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Rise of the Machine Spirit",
+					"objectives": [
+						{
+							"id": "GT21.00.07.01",
+							"name": "Inload Data-psalm",
+							"description": "[i]Progressive Objective[/i]\nIf you select this objective, then units in your army can perform the following action.",
+							"actions": [
+								{
+									"id": "EW.00.07.01a",
+									"name": "Inload Data-psalm (Action)",
+									"description": "[i]Action[/i]\nOne or more units from your army can start to perform this action at the end of your Movement phase. Each unit that starts to perform this action must be within range of a different objective marker. A unit cannot start this action while any enemy units (excluding [b]AIRCRAFT[/b]) are in range of the same objective marker. This action is completed at the end of your next Command phase, and you score a number of victory points depending on how many units completed this action this phase, as follows: 1 gives 1pt, 3 give 6pts, 4 give 10pts."
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Show of Force",
+					"objectives": [
+						{
+							"id": "GT21.00.08.01",
+							"name": "Minimize Losses",
+							"description": "[i]End Game Objective[/i]\nAt the start of the battle, add up the number of units in your army ~ this is your army’s Strength. If a unit splits to form two or more individual units during the battle, then immediately increase your army's Strength accordingly (e.g. if one unit in your army splits to form three individual units, your army’s Strength is increased by 2). Ifa unit merges with another to form a combined unit during the battle, then decrease your army’s Strength accordingly (e.g. if two units from your army merge to form one unit, you immediately decrease your army's Strength by 1). At the end of the battle, add up how many units from your army are left on the battlefield, including all units embarked within [b]TRANSPORT[/b]s, but excluding all units that have been added to your army during the battle. If the total is 75% or more of your army’s Strength, score 15 victory points; if the total is less than 75%, but is 50% or more of your army’s Strength, score 10 victory points; if the total is less than 50%, but is 25% or more of your army’s Strength, score 5 victory points."
+						}
+					]
+				},
+				{
+					"name": "Reconaissance Mission",
+					"objectives": [
+						{
+							"id": "GT21.00.09.01",
+							"name": "Recon Sweep",
+							 "description": "[i]Progressive Objective[/i]\nIf you select this objective, then units in your army can perform the following action.",
+							"actions": [
+								{
+									"id": "GT21.00.09.01a",
+									"name": "Recon Sweep (Action)",
+									"description": "[i]Action[/i]\nOne unit from your army can start to perform this action at the start of your Movement phase, if it is wholly within a table quarter that has not already been reconnoitred by a unit from your army and it is more than 9\" from the centre of the battlefield. The action is completed at the end of your turn and, provided the unit is still wholly within that table quarter, that table quarter is said to have been reconnoitred by your forces. You score a number of victory points for the number of table quarters that have been reconnoitred by your forces by the end of the battle, as follows: 1 gives 3pts, 2 give 6pts, 3 give 10pts, 4 give 15pts."
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Retrieval Mission",
+					"objectives": [
+						{
+							"id": "GT21.00.10.01",
+							"name": "Minimize Losses",
+							"description": "[i]End Game Objective[/i]\nAt the start of the battle, add up the number of units in your army — this is your army’s Strength. If a unit splits to form two or more individual units during the battle, then immediately increase your army’s Strength accordingly (e.g. if one unit in your army splits to form three individual units, your army’s Strength is increased by 2). If a unit merges with another to form a combined unit during the battle, then decrease your army’s strength accordingly (e.g. if two units from your army merge to form one unit, you immediately decrease your army’s strength by 1). At the end of the battle, add up how many units from your army are left on the battlefield, including all units embarked within [b]TRANSPORT[/b]s, but excluding all units that have been added to your army during the battle. If the total is 75% or more of your army’s Strength, score 15 victory points; if the total is less than 75%, but is 50% or more of your army's Strength, score 10 victory points; if the total is less than 50%, but is 25% or more of your army's Strength, score 5 victory points."
+						}
+					]
+				},
+				{
+					"name": "Scorched Earth",
+					"objectives": [
+						{
+							"id": "GT21.00.11.01",
+							"name": "Raze",
+							"description": "[i]End Game Objective[/i]\nAt the end of the battle, a player scores 6 victory points if one objective marker was removed from the battlefield due to a successful Raze Objective action performed by a unit from their army during the battle, and 12 victory points if two objective markers were so removed.",
+							"actions": [
+								{
+									"id": "GT21.00.11.01a",
+									"name": "Raze Objective (Action)",
+									"description": "[i]Action[/i]\nOne unit from your army can start to perform this action at the start of your Movement phase if it is within range of an objective marker that can be razed and no enemy units (excluding [b]AIRCRAFT[/b]) are within range of that objective marker. Player A can only attempt to raze the objective markers labelled B, and player B can only attempt to raze the objective markers labelled A. The action is completed at the end of your turn. If this action is successfully completed, that objective marker is razed and removed from the battlefield."
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Vital Intelligence",
+					"objectives": [
+						{
+							"id": "GT21.00.12.01",
+							"name": "Data Intercept",
+							"description": "[i]Progressive Objective[/i]\nEach time a unit from your army successfully completes the following action, you score a number of victory points equal to the number of objective markers you currently control.",
+							"actions": [
+								{
+									"id": "GT21.00.12.01a",
+									"name": "Data Intercept (Action)",
+									"description": "[i]Action[/i]\nOne unit from your army can start to perform this action at the end of your Movement phase if it is within range of an objective marker and no enemy units (excluding [b]AIRCRAFT[/b]) are within range of that objective marker. The action is completed at the end of your next Command phase so long as the unit performing it is still within range of the same objective marker."
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Surround and Destroy",
+					"objectives": [
+						{
+							"id": "GT21.00.13.01",
+							"name": "Surround Them",
+							"description": "[i]Progressive and End Game Objective[/i]\nScore 4 victory points at the end of your Command phase, and at the end of the battle if you control both the objective markers in your deployment zone and one or more objective markers in your opponent's deployment zone. Score 8 victory points instead if you control all four objective markers that are in deployment zones."
+						}
+					]
+				},
+				{
+					"name": "Battle Lines",
+					"objectives": [
+						{
+							"id": "GT21.00.14.01",
+							"name": "Vital Ground",
+							"description": "[i]Progressive Objective[/i]\nAt the end of each of your Command phases, you score 3 victory points if you control the objective marker in your opponent's deployment zone, and score 2 victory points for each objective marker that you control that is not in either player's deployment zone (for a maximum of 7 victory points). This secondary objective cannot be scored in the first battle round."
+						}
+					]
+				},
+				{
+					"name": "The Scouring",
+					"objectives": [
+						{
+							"id": "GT21.00.15.01",
+							"name": "Strategic Scan",
+							"description": "[i]End Game Objective[/i]\nIf you select this objective, then units in your army can perform the following action.",
+							"actions": [
+								{
+									"id": "GT21.00.15.01a",
+									"name": "Strategic Scan (Action)",
+									"description": "[i]Action[/i]\nOne or more units from your army can start to perform this action at the end of your Movement phase. Each unit from your army that starts to perform this action must be in range of a different objective marker that has not already been scanned by a unit from your army (see below). A unit cannot start this action while there are any enemy units (excluding [b]AIRCRAFT[/b]) in range of the same objective marker. This action is completed at the start of your next Command phase, or at the end of the battle (whichever happens first). If this action is successfully completed, that objective marker is said to have been scanned by your army. You score a number of victory points at the end of the battle depending on how many times units from your army completed this action this battle, as follow: 1 gives 3 pts, 2 give 6 pts, 3 give 10pts, 4+ give 15 pts"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Overrun",
+					"objectives": [
+						{
+							"id": "GT21.00.16.01",
+							"name": "Overrun",
+							"description": "[i]Progressive Objective[/i]\nScore a number of victory points at the end of your Command phase if you control one or more of the objective markers that are within your opponent's territory, as follow: 1 give 2pts, 2 give 3pts, 3 give 5pts."
+						}
+					]
+				},
+				{
+					"name": "Sweep and Clear",
+					"objectives": [
+						{
+							"id": "GT21.00.17.01",
+							"name": "Direct Assault",
+							"description": "[i]Progressive Objective[/i]\nScore 3 victory points if you control either the objective marker in the centre of the battlefield or the objective marker in your opponent's deployment zone at the end of your turn, or 5 victory points if you control both of these objective markers at the end of your turn."
+						}
+					]
+				},
+				{
+					"name": "Priority Target",
+					"objectives": [
+						{
+							"id": "GT21.00.18.01",
+							"name": "Priority Targets",
+							"description": "[i]Progressive Objective[/i]\nScore 3 victory points if you control either of the Priority Objective Markers (see left) at the end of your turn, or 5 victory points if you control both of these objective markers at the end of your turn. "
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/9e/index.json
+++ b/9e/index.json
@@ -3,6 +3,7 @@
 	"packs": [
 		"ew",
 		"gt2020",
+		"gt2021",
 		"factions"
 	]
 }


### PR DESCRIPTION
Add GT2021 as an option for secondary objective selection.

Notes:
- This is untested, sorry; not sure how to test these changes live. Note in particular that I've used [b] tags for keywords and I've no idea if that actually works, I just noted that [i] was used and apparently did, so I've tried it. You can just search-and-replace all instances of [b] or [/b] with nothing if it doesn't work.
- It hasn't been proofread by anyone but me, though I'll wager I've done a better job than GW, since I've corrected a couple of _their_ mistakes 😊
- The GT2020 set was strangely inconsistent in that it used an "actions" array for mission-specific objectives with actions, but not for generic objectives with actions, so I'm not sure which was preferred. In this set, I've used the "actions" array consistently for both. Easy to change if that's not preferred, though I think it's always better to have the data more descriptive, and change the code to combine the two sections if a distinction is unwanted.